### PR TITLE
Updated repository link

### DIFF
--- a/Graph-Easy/Build.PL
+++ b/Graph-Easy/Build.PL
@@ -37,7 +37,7 @@ my $build = Test::Run::Builder->new(
     {
         resources =>
         {
-            repository => "https://bitbucket.org/shlomif/perl-graph-easy",
+            repository => "https://github.com/shlomif/perl-graph-easy",
         },
         keywords =>
         [


### PR DESCRIPTION
On CPAN, the old link leads to an error page.